### PR TITLE
writeBuffer() changes should fix issues #10/#11

### DIFF
--- a/utility/Enc28J60Network.cpp
+++ b/utility/Enc28J60Network.cpp
@@ -461,6 +461,9 @@ Enc28J60Network::readBuffer(uint16_t len, uint8_t* data)
 void
 Enc28J60Network::writeBuffer(uint16_t len, uint8_t* data)
 {
+  // verify there's data to send
+  if( !len ) return;
+
   CSACTIVE;
   // issue write command
   SPDR = ENC28J60_WRITE_BUF_MEM;


### PR DESCRIPTION
I don't actually have this chip to test, but I had experienced the exact same issue when using the W5200. It also didn't do a length check before initiating a transfer.
