### PR TITLE
Fixed compiler warning in _eatBlock.

### DIFF
--- a/UIPClient.cpp
+++ b/UIPClient.cpp
@@ -530,8 +530,10 @@ UIPClient::_eatBlock(memhandle* block)
 #endif
   memhandle* end = block+(UIP_SOCKET_NUMPACKETS-1);
   UIPEthernet.network.freeBlock(*block);
-  while(block < end)
-    *block = *((block++)+1);
+  while(block < end) {
+    *block = *(block + 1);
+    block++;
+  }
   *end = NOBLOCK;
 #ifdef UIPETHERNET_DEBUG_CLIENT
   for (uint8_t i = 0; i < UIP_SOCKET_NUMPACKETS; i++)


### PR DESCRIPTION
This should fix the compiler warning in #34 (and possibly solve the problem in #39). I have tested the change and it works for me (Arduino 1.0.5 on OSX). But please verify with different IDEs and compilers that it is ok as I have only one setup.
