### PR TITLE
Enc28J60Network::setReadPtr + copyPacket fix handling of receive-buffer boundary

### DIFF
--- a/utility/Enc28J60Network.cpp
+++ b/utility/Enc28J60Network.cpp
@@ -248,8 +248,8 @@ uint16_t
 Enc28J60Network::setReadPtr(memhandle handle, memaddress position, uint16_t len)
 {
   memblock *packet = handle == UIP_RECEIVEBUFFERHANDLE ? &receivePkt : &blocks[handle];
-  memaddress start = packet->begin + position;
-  
+  memaddress start = handle == UIP_RECEIVEBUFFERHANDLE && packet->begin + position > RXSTOP_INIT ? packet->begin + position-RXSTOP_INIT+RXSTART_INIT : packet->begin + position;
+
   writeRegPair(ERDPTL, start);
   
   if (len > packet->size - position)
@@ -313,7 +313,8 @@ Enc28J60Network::copyPacket(memhandle dest_pkt, memaddress dest_pos, memhandle s
 {
   memblock *dest = &blocks[dest_pkt];
   memblock *src = src_pkt == UIP_RECEIVEBUFFERHANDLE ? &receivePkt : &blocks[src_pkt];
-  enc28J60_mempool_block_move_callback(dest->begin+dest_pos,src->begin+src_pos,len);
+  memaddress start = src_pkt == UIP_RECEIVEBUFFERHANDLE && src->begin + src_pos > RXSTOP_INIT ? src->begin + src_pos-RXSTOP_INIT+RXSTART_INIT : src->begin + src_pos;
+  enc28J60_mempool_block_move_callback(dest->begin+dest_pos,start,len);
   // Move the RX read pointer to the start of the next received packet
   // This frees the memory we just read out
   setERXRDPT();


### PR DESCRIPTION
further Fix for #92 #90 #88 #75 #71 #63
