### PR TITLE
added ability of setting CS pin inside sketch

### DIFF
--- a/UIPEthernet.cpp
+++ b/UIPEthernet.cpp
@@ -56,13 +56,13 @@ UIPEthernetClass::UIPEthernetClass()
 
 #if UIP_UDP
 int
-UIPEthernetClass::begin(const uint8_t* mac)
+UIPEthernetClass::begin(const uint8_t* mac, int cs_pin)
 {
   static DhcpClass s_dhcp;
   _dhcp = &s_dhcp;
 
   // Initialise the basic info
-  init(mac);
+  init(mac, cs_pin);
 
   // Now try to get our config info from a DHCP server
   int ret = _dhcp->beginWithDHCP((uint8_t*)mac);
@@ -77,32 +77,32 @@ UIPEthernetClass::begin(const uint8_t* mac)
 #endif
 
 void
-UIPEthernetClass::begin(const uint8_t* mac, IPAddress ip)
+UIPEthernetClass::begin(const uint8_t* mac, IPAddress ip, int cs_pin)
 {
   IPAddress dns = ip;
   dns[3] = 1;
-  begin(mac, ip, dns);
+  begin(mac, ip, dns, cs_pin);
 }
 
 void
-UIPEthernetClass::begin(const uint8_t* mac, IPAddress ip, IPAddress dns)
+UIPEthernetClass::begin(const uint8_t* mac, IPAddress ip, IPAddress dns, int cs_pin)
 {
   IPAddress gateway = ip;
   gateway[3] = 1;
-  begin(mac, ip, dns, gateway);
+  begin(mac, ip, dns, gateway, cs_pin);
 }
 
 void
-UIPEthernetClass::begin(const uint8_t* mac, IPAddress ip, IPAddress dns, IPAddress gateway)
+UIPEthernetClass::begin(const uint8_t* mac, IPAddress ip, IPAddress dns, IPAddress gateway, int cs_pin)
 {
   IPAddress subnet(255, 255, 255, 0);
-  begin(mac, ip, dns, gateway, subnet);
+  begin(mac, ip, dns, gateway, subnet, cs_pin);
 }
 
 void
-UIPEthernetClass::begin(const uint8_t* mac, IPAddress ip, IPAddress dns, IPAddress gateway, IPAddress subnet)
+UIPEthernetClass::begin(const uint8_t* mac, IPAddress ip, IPAddress dns, IPAddress gateway, IPAddress subnet, int cs_pin)
 {
-  init(mac);
+  init(mac, cs_pin);
   configure(ip,dns,gateway,subnet);
 }
 
@@ -314,10 +314,10 @@ sendandfree:
   return true;
 }
 
-void UIPEthernetClass::init(const uint8_t* mac) {
+void UIPEthernetClass::init(const uint8_t* mac, int cs_pin) {
   periodic_timer = millis() + UIP_PERIODIC_TIMER;
 
-  Enc28J60Network::init((uint8_t*)mac);
+  Enc28J60Network::init((uint8_t*)mac, cs_pin);
   uip_seteth_addr(mac);
 
   uip_init();

--- a/UIPEthernet.h
+++ b/UIPEthernet.h
@@ -65,11 +65,11 @@ class UIPEthernetClass
 public:
   UIPEthernetClass();
 
-  int begin(const uint8_t* mac);
-  void begin(const uint8_t* mac, IPAddress ip);
-  void begin(const uint8_t* mac, IPAddress ip, IPAddress dns);
-  void begin(const uint8_t* mac, IPAddress ip, IPAddress dns, IPAddress gateway);
-  void begin(const uint8_t* mac, IPAddress ip, IPAddress dns, IPAddress gateway, IPAddress subnet);
+  int begin(const uint8_t* mac, int cs_pin=SS);
+  void begin(const uint8_t* mac, IPAddress ip, int cs_pin=SS);
+  void begin(const uint8_t* mac, IPAddress ip, IPAddress dns, int cs_pin=SS);
+  void begin(const uint8_t* mac, IPAddress ip, IPAddress dns, IPAddress gateway, int cs_pin=SS);
+  void begin(const uint8_t* mac, IPAddress ip, IPAddress dns, IPAddress gateway, IPAddress subnet, int cs_pin=SS);
 
   // maintain() must be called at regular intervals to process the incoming serial
   // data and issue IP events to the sketch.  It does not return until all IP
@@ -92,7 +92,7 @@ private:
 
   static unsigned long periodic_timer;
 
-  static void init(const uint8_t* mac);
+  static void init(const uint8_t* mac, int cs_pin);
   static void configure(IPAddress ip, IPAddress dns, IPAddress gateway, IPAddress subnet);
 
   static void tick();

--- a/utility/Enc28J60Network.cpp
+++ b/utility/Enc28J60Network.cpp
@@ -35,6 +35,8 @@ extern "C" {
 #include "HardwareSerial.h"
 #endif
 
+int ENC28J60_CS;
+
 // set CS to 0 = active
 #define CSACTIVE digitalWrite(ENC28J60_CONTROL_CS, LOW)
 // set CS to 1 = passive
@@ -47,10 +49,12 @@ uint8_t Enc28J60Network::bank=0xff;
 
 struct memblock Enc28J60Network::receivePkt;
 
-void Enc28J60Network::init(uint8_t* macaddr)
+void Enc28J60Network::init(uint8_t* macaddr, int cs_pin)
 {
   MemoryPool::init(); // 1 byte in between RX_STOP_INIT and pool to allow prepending of controlbyte
   // initialize I/O
+  // set CS pin
+  ENC28J60_CS = cs_pin;
   // ss as output:
   pinMode(ENC28J60_CONTROL_CS, OUTPUT);
   CSPASSIVE; // ss=0

--- a/utility/Enc28J60Network.h
+++ b/utility/Enc28J60Network.h
@@ -27,7 +27,7 @@
 
 #include "mempool.h"
 
-#define ENC28J60_CONTROL_CS     SS
+#define ENC28J60_CONTROL_CS     ENC28J60_CS
 #define SPI_MOSI        MOSI
 #define SPI_MISO        MISO
 #define SPI_SCK         SCK
@@ -76,7 +76,7 @@ public:
   void powerOff();
   bool linkStatus();
 
-  static void init(uint8_t* macaddr);
+  static void init(uint8_t* macaddr, int cs_pin);
   static memhandle receivePacket();
   static void freePacket();
   static memaddress blockSize(memhandle handle);


### PR DESCRIPTION
Now it is possible to set CS pin for ENC28J60 in the following way:
Ethernet.begin(mac, 14);
or use default:
Ethernet.begin(mac);