### PR TITLE
Add category to library.properties

### DIFF
--- a/UIPEthernet/library.properties
+++ b/UIPEthernet/library.properties
@@ -3,6 +3,7 @@ author=ntruchsess
 email=Norbert Truchsess <norbert.truchsess@t-online.de>
 sentence=Ethernet library for ENC28J60
 paragraph=implements the same API as stock Ethernet-lib. Just replace the include of Ethernet.h with UIPEthernet.h
+category=Communication
 url=https://github.com/ntruchsess/arduino_uip
 architectures=*
 version=1.50


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library UIPEthernet is not valid.
Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6.