### PR TITLE
Fixes for 32-bit processors

### DIFF
--- a/Dhcp.cpp
+++ b/Dhcp.cpp
@@ -289,7 +289,9 @@ uint8_t DhcpClass::parseDHCPResponse(unsigned long responseTimeout, uint32_t& tr
 
         while (_dhcpUdpSocket.available() > 0) 
         {
-            switch (_dhcpUdpSocket.read()) 
+//PAH save the byte for later
+            unsigned char sread = _dhcpUdpSocket.read();
+            switch (sread) 
             {
                 case endOption :
                     break;
@@ -370,6 +372,8 @@ uint8_t DhcpClass::parseDHCPResponse(unsigned long responseTimeout, uint32_t& tr
                     }
                     break;
             }
+//PAH break from the loop if endOption was read
+            if(sread == endOption)break;
         }
     }
 

--- a/Dhcp.h
+++ b/Dhcp.h
@@ -140,12 +140,13 @@ class DhcpClass {
 private:
   uint32_t _dhcpInitialTransactionId;
   uint32_t _dhcpTransactionId;
-  uint8_t  _dhcpMacAddr[6];
-  uint8_t  _dhcpLocalIp[4];
-  uint8_t  _dhcpSubnetMask[4];
-  uint8_t  _dhcpGatewayIp[4];
-  uint8_t  _dhcpDhcpServerIp[4];
-  uint8_t  _dhcpDnsServerIp[4];
+//PAH force alignment to 4 bytes for 32-bit processors
+  uint8_t  _dhcpMacAddr[6] __attribute__ ((aligned (4)));
+  uint8_t  _dhcpLocalIp[4] __attribute__ ((aligned (4)));
+  uint8_t  _dhcpSubnetMask[4] __attribute__ ((aligned (4)));
+  uint8_t  _dhcpGatewayIp[4] __attribute__ ((aligned (4)));
+  uint8_t  _dhcpDhcpServerIp[4] __attribute__ ((aligned (4)));
+  uint8_t  _dhcpDnsServerIp[4] __attribute__ ((aligned (4)));
   uint32_t _dhcpLeaseTime;
   uint32_t _dhcpT1, _dhcpT2;
   signed long _renewInSec;

--- a/utility/util.h
+++ b/utility/util.h
@@ -1,7 +1,8 @@
 #ifndef UTIL_H
 #define UTIL_H
 
-#define htons(x) ( ((x)<<8) | (((x)>>8)&0xFF) )
+//PAH - Add & 0xff00 so that it works on 32-bit processors
+#define htons(x) ( (((x)<<8) & 0xff00) | (((x)>>8)&0xFF) )
 #define ntohs(x) htons(x)
 
 #define htonl(x) ( ((x)<<24 & 0xFF000000UL) | \


### PR DESCRIPTION
Fixes to dhcp so that it will work on 32-bit processor and one modification to make it process faster by not waiting for a timeout before finishing.
Fix to htons so that it works on 32-bit processors.