### PR TITLE
Remove '' category and Invalid version warnings

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,8 +3,9 @@ author=ntruchsess
 email=Norbert Truchsess <norbert.truchsess@t-online.de>
 sentence=Ethernet library for ENC28J60
 paragraph=implements the same API as stock Ethernet-lib. Just replace the include of Ethernet.h with UIPEthernet.h
+category=Communication
 url=https://github.com/ntruchsess/arduino_uip
 architectures=avr
-version=1.04
+version=1.0.4
 dependencies=
 core-dependencies=arduino (>=1.5.0)


### PR DESCRIPTION
library.properties does not include the category keyword. This causes Arduino IDE to create a warning: 
WARNING: Category '' in library UIPEthernet is not valid. Setting to 'Uncategorized'

version string is 1.04 this also causes a warning. This is a major nuisance because the warning message keeps repeating itself:
Invalid version found: 1.04
Arduino IDE expects the version number to be in the 1.0.4 format instead of 1.04. 1.04 causes library to report "invalid" version. Hence the warning.