### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/UIPEthernet/keywords.txt
+++ b/UIPEthernet/keywords.txt
@@ -6,9 +6,9 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-UIPEthernet KEYWORD1
-UIPServer KEYWORD1
-UIPClient KEYWORD1
+UIPEthernet	KEYWORD1
+UIPServer	KEYWORD1
+UIPClient	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords